### PR TITLE
Build universal2 wheels for macOS instead

### DIFF
--- a/.github/workflows/build-and-upload-to-pypi.yml
+++ b/.github/workflows/build-and-upload-to-pypi.yml
@@ -39,7 +39,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.11.2
         env:
           CIBW_ARCHS_LINUX: auto64 aarch64
-          CIBW_ARCHS_MACOS: x86_64 arm64
+          CIBW_ARCHS_MACOS: universal2
 
       - uses: actions/upload-artifact@v3
         if: github.event_name == 'release' && github.event.action == 'created'


### PR DESCRIPTION
The arm64 wheels aren't getting built properly, so let's look into using `universal2` per guidelines on https://cibuildwheel.readthedocs.io/en/stable/faq/#apple-silicon.