### PR TITLE
Enable 'auto' build for linux wheels

### DIFF
--- a/.github/workflows/build-and-upload-to-pypi.yml
+++ b/.github/workflows/build-and-upload-to-pypi.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Build and test wheels
         uses: pypa/cibuildwheel@v2.11.2
         env:
-          CIBW_ARCHS_LINUX: auto64 aarch64
+          CIBW_ARCHS_LINUX: auto aarch64
           CIBW_ARCHS_MACOS: x86_64 arm64
 
       - uses: actions/upload-artifact@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,8 @@ build-backend = "setuptools.build_meta"
 [tool.cibuildwheel]
 build-frontend = "build"
 build = "cp3*"
-skip = ["*-win32", "*-manylinux_i686", "*-musllinux_*"]
-archs = ["auto64"]
+skip = ["*-win32", "*-musllinux_*"]
+archs = ["auto"]
 test-requires = ['pytest']
 test-command = [
     'cd {project}',


### PR DESCRIPTION
Hi there!

Thanks again for creating this fork, I'm using this for supporting Python 3.11 in [CleverCSV](https://github.com/alan-turing-institute/CleverCSV). I'd like to request changing the cibuildwheel configuration to support i686 builds as well (these are failing for my project because of missing wheels from this project).

I've tested that this works without any issues on [my fork](https://github.com/GjjvdBurg/cChardet/actions/runs/3897491312/jobs/6655230274).

Thanks!  