### PR TITLE
Fix pep517 builds

### DIFF
--- a/.github/workflows/build-and-upload-to-pypi.yml
+++ b/.github/workflows/build-and-upload-to-pypi.yml
@@ -22,7 +22,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        submodules: 'src/ext/uchardet'
+        with:
+           submodules: 'src/ext/uchardet'
 
       - name: Set up QEMU
         if: runner.os == 'Linux'
@@ -47,7 +48,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        submodules: 'src/ext/uchardet'
+        with:
+          submodules: 'src/ext/uchardet'
 
       - name: Build sdist
         run: pipx run build --sdist

--- a/.github/workflows/build-and-upload-to-pypi.yml
+++ b/.github/workflows/build-and-upload-to-pypi.yml
@@ -36,6 +36,7 @@ jobs:
         env:
           CIBW_ARCHS_LINUX: auto aarch64
           CIBW_ARCHS_MACOS: x86_64 arm64
+          CIBW_SKIP: cp36-*
 
       - uses: actions/upload-artifact@v3
         if: github.event_name == 'release' && github.event.action == 'created'

--- a/.github/workflows/build-and-upload-to-pypi.yml
+++ b/.github/workflows/build-and-upload-to-pypi.yml
@@ -34,9 +34,8 @@ jobs:
       - name: Build and test wheels
         uses: pypa/cibuildwheel@v2.11.2
         env:
-          CIBW_ARCHS_LINUX: auto aarch64
+          CIBW_ARCHS_LINUX: i686
           CIBW_ARCHS_MACOS: x86_64 arm64
-          CIBW_SKIP: cp36-*
 
       - uses: actions/upload-artifact@v3
         if: github.event_name == 'release' && github.event.action == 'created'

--- a/.github/workflows/build-and-upload-to-pypi.yml
+++ b/.github/workflows/build-and-upload-to-pypi.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-11]
+        os: [ubuntu-latest, macos-11, windows-2019]
 
     steps:
       - uses: actions/checkout@v3
@@ -34,7 +34,7 @@ jobs:
       - name: Build and test wheels
         uses: pypa/cibuildwheel@v2.11.2
         env:
-          CIBW_ARCHS_LINUX: i686
+          CIBW_ARCHS_LINUX: auto aarch64
           CIBW_ARCHS_MACOS: x86_64 arm64
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/build-and-upload-to-pypi.yml
+++ b/.github/workflows/build-and-upload-to-pypi.yml
@@ -22,12 +22,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-
-      - name: Checkout submodules
-        shell: bash
-        run: |
-          git submodule sync --recursive
-          git submodule update --init --force --recursive --depth=1
+        submodules: 'src/ext/uchardet'
 
       - name: Set up QEMU
         if: runner.os == 'Linux'
@@ -52,6 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        submodules: 'src/ext/uchardet'
 
       - name: Build sdist
         run: pipx run build --sdist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,15 +13,21 @@ test-command = [
     'python -m pytest {project}'
 ]
 
+environment = {INCLUDE_PATH="/usr/local/include/uchardet", LIBRARY_PATH="/usr/local/lib64/"}
 before-build = [
     "git submodule sync --recursive",
     "git submodule update --init --force --recursive --depth=1",
+    "test -d {project}/src/ext/uchardet/build || (cd {project}/src/ext/uchardet/ && mkdir build && cd build && cmake .. && make && make install)",
+    "cat {project}/src/ext/uchardet/build/Makefile"
 ]
 
 [tool.cibuildwheel.macos]
+environment = {INCLUDE_PATH="/usr/local/include/uchardet", LIBRARY_PATH="/usr/local/lib/"}
 before-build = [
     "git submodule sync --recursive",
     "git submodule update --init --force --recursive --depth=1",
+    "test -d {project}/src/ext/uchardet/build || (cd {project}/src/ext/uchardet/ && mkdir build && cd build && cmake -DCMAKE_MACOSX_RPATH=1 -DCMAKE_INSTALL_NAME_DIR=$LIBRARY_PATH -DCMAKE_BUILD_RPATH=$LIBRARY_PATH .. && make && make install)",
+    "cat {project}/src/ext/uchardet/build/Makefile"
 ]
 
 [tool.cibuildwheel.windows]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,20 @@ test-command = [
     'python -m pytest {project}'
 ]
 
+before-build = [
+    "git submodule sync --recursive",
+    "git submodule update --init --force --recursive --depth=1",
+]
+
+[tool.cibuildwheel.macos]
+before-build = [
+    "git submodule sync --recursive",
+    "git submodule update --init --force --recursive --depth=1",
+]
 
 [tool.cibuildwheel.windows]
 before-build = [
+    "git submodule sync --recursive",
+    "git submodule update --init --force --recursive --depth=1",
     "make pip"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,6 @@ environment = {INCLUDE_PATH="/usr/local/include/uchardet", LIBRARY_PATH="/usr/lo
 before-build = [
     "git submodule sync --recursive",
     "git submodule update --init --force --recursive --depth=1",
-    "test -d {project}/src/ext/uchardet/build || (cd {project}/src/ext/uchardet/ && mkdir build && cd build && cmake .. && make && make install)",
-    "cat {project}/src/ext/uchardet/build/Makefile"
 ]
 
 [tool.cibuildwheel.macos]
@@ -26,8 +24,6 @@ environment = {INCLUDE_PATH="/usr/local/include/uchardet", LIBRARY_PATH="/usr/lo
 before-build = [
     "git submodule sync --recursive",
     "git submodule update --init --force --recursive --depth=1",
-    "test -d {project}/src/ext/uchardet/build || (cd {project}/src/ext/uchardet/ && mkdir build && cd build && cmake -DCMAKE_MACOSX_RPATH=1 -DCMAKE_INSTALL_NAME_DIR=$LIBRARY_PATH -DCMAKE_BUILD_RPATH=$LIBRARY_PATH .. && make && make install)",
-    "cat {project}/src/ext/uchardet/build/Makefile"
 ]
 
 [tool.cibuildwheel.windows]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,24 +13,8 @@ test-command = [
     'python -m pytest {project}'
 ]
 
-environment = {INCLUDE_PATH="/usr/local/include/uchardet", LIBRARY_PATH="/usr/local/lib64/"}
-before-build = [
-    "git submodule sync --recursive",
-    "git submodule update --init --force --recursive --depth=1",
-    "test -d {project}/src/ext/uchardet/build || (cd {project}/src/ext/uchardet/ && mkdir build && cd build && cmake .. && make && make install)",
-]
-
-[tool.cibuildwheel.macos]
-environment = {INCLUDE_PATH="/usr/local/include/uchardet", LIBRARY_PATH="/usr/local/lib/"}
-before-build = [
-    "git submodule sync --recursive",
-    "git submodule update --init --force --recursive --depth=1",
-    "test -d {project}/src/ext/uchardet/build || (cd {project}/src/ext/uchardet/ && mkdir build && cd build && cmake -DCMAKE_MACOSX_RPATH=1 -DCMAKE_INSTALL_NAME_DIR=$LIBRARY_PATH -DCMAKE_BUILD_RPATH=$LIBRARY_PATH .. && make && make install)",
-]
 
 [tool.cibuildwheel.windows]
 before-build = [
-    "git submodule sync --recursive",
-    "git submodule update --init --force --recursive --depth=1",
     "make pip"
 ]

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,8 @@
 # coding: utf-8
 
 import os
-import sys
-import glob
 import codecs
 import re
-import pkgconfig
 from distutils.command.build_ext import build_ext
 from distutils import sysconfig
 
@@ -17,19 +14,30 @@ except ImportError:
 
 from Cython.Build import cythonize
 
-cchardet_dir = os.path.join("src", "cchardet") + os.path.sep
 
-try:
-    ext_args = pkgconfig.parse('uchardet')
-except pkgconfig.PackageNotFoundError:
-    include_path = os.environ.get('INCLUDE_PATH')
-    library_path = os.environ.get('LIBRARY_PATH')
+join = os.path.join
 
-    ext_args = {
-        'include_dirs': include_path.split(os.pathsep) if include_path else [],
-        'library_dirs': library_path.split(os.pathsep) if library_path else [],
-        'libraries': ['uchardet'],
-    }
+cchardet_dir = join("src", "cchardet") + os.path.sep
+uchardet_dir = join("src", "ext", "uchardet", "src")
+uchardet_lang_models_dir = join(uchardet_dir, "LangModels")
+
+cchardet_sources = [join("src", "cchardet", "_cchardet.pyx")]
+uchardet_sources = [
+    join(uchardet_dir, file)
+    for file in os.listdir(uchardet_dir)
+    if file.endswith(".cpp")
+]
+uchardet_lang_source = [
+    join(uchardet_lang_models_dir, file)
+    for file in os.listdir(uchardet_lang_models_dir)
+    if file.endswith(".cpp")
+]
+sources = cchardet_sources + uchardet_sources + uchardet_lang_source
+
+ext_args = {
+    "include_dirs": uchardet_dir.split(os.pathsep),
+    "library_dirs": uchardet_dir.split(os.pathsep),
+}
 
 # Remove the "-Wstrict-prototypes" compiler option, which isn't valid for C++.
 cfg_vars = sysconfig.get_config_vars()
@@ -40,61 +48,59 @@ for key, value in cfg_vars.items():
         # cfg_vars[key] = value.replace("-O2", "-O3")
 
 
-cchardet_module = Extension(
-    'cchardet._cchardet',
-    [
-        os.path.join('src', 'cchardet', '_cchardet.pyx')
-    ],
-    language='c++',
-    **ext_args
-)
+cchardet_module = Extension("cchardet._cchardet", sources, language="c++", **ext_args)
 
 
 def read(f):
     return open(os.path.join(os.path.dirname(__file__), f)).read().strip()
 
 
-with codecs.open(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'src', 'cchardet', 'version.py'), 'r', 'latin1') as fp:
+with codecs.open(
+    os.path.join(
+        os.path.abspath(os.path.dirname(__file__)), "src", "cchardet", "version.py"
+    ),
+    "r",
+    "latin1",
+) as fp:
     try:
-        version = re.findall(
-            r"^__version__ = '([^']+)'\r?$", fp.read(), re.M)[0]
+        version = re.findall(r"^__version__ = '([^']+)'\r?$", fp.read(), re.M)[0]
     except IndexError:
-        raise RuntimeError('Unable to determine version.')
+        raise RuntimeError("Unable to determine version.")
 
 setup(
-    name='faust-cchardet',
-    author='PyYoshi',
-    author_email='myoshi321go@gmail.com',
-    url=r'https://github.com/faust-streaming/cChardet',
-    description='cChardet is high speed universal character encoding detector.',
-    long_description='\n\n'.join((read('README.rst'), read('CHANGES.rst'))),
+    name="faust-cchardet",
+    author="PyYoshi",
+    author_email="myoshi321go@gmail.com",
+    url=r"https://github.com/faust-streaming/cChardet",
+    description="cChardet is high speed universal character encoding detector.",
+    long_description="\n\n".join((read("README.rst"), read("CHANGES.rst"))),
     version=version,
-    license='Mozilla Public License',
+    license="Mozilla Public License",
     classifiers=[
-        'License :: OSI Approved :: Mozilla Public License 1.1 (MPL 1.1)',
-        'License :: OSI Approved :: GNU General Public License (GPL)',
-        'License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)',
-        'Programming Language :: Cython',
-        'Programming Language :: Python',
-        'Topic :: Software Development :: Libraries',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10', 
-        'Programming Language :: Python :: 3.11',
+        "License :: OSI Approved :: Mozilla Public License 1.1 (MPL 1.1)",
+        "License :: OSI Approved :: GNU General Public License (GPL)",
+        "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)",
+        "Programming Language :: Cython",
+        "Programming Language :: Python",
+        "Topic :: Software Development :: Libraries",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
-    keywords=[
-        'cython',
-        'chardet',
-        'charsetdetect'
+    keywords=["cython", "chardet", "charsetdetect"],
+    cmdclass={"build_ext": build_ext},
+    package_dir={"": "src"},
+    packages=[
+        "cchardet",
     ],
-    cmdclass={'build_ext': build_ext},
-    package_dir={'': 'src'},
-    packages=['cchardet', ],
-    scripts=['bin/cchardetect'],
-    ext_modules=cythonize([
-        cchardet_module,
-    ]),
+    scripts=["bin/cchardetect"],
+    ext_modules=cythonize(
+        [
+            cchardet_module,
+        ]
+    ),
 )

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,9 @@ sources = cchardet_sources + uchardet_sources + uchardet_lang_source
 ext_args = {
     "include_dirs": uchardet_dir.split(os.pathsep),
     "library_dirs": uchardet_dir.split(os.pathsep),
+    "extra_compile_args": ["-DNDEBUG", "-Dlibuchardet_EXPORTS", "-Wall", "-O3", "-std=c++11"],
 }
+
 
 # Remove the "-Wstrict-prototypes" compiler option, which isn't valid for C++.
 cfg_vars = sysconfig.get_config_vars()

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ sources = cchardet_sources + uchardet_sources + uchardet_lang_source
 ext_args = {
     "include_dirs": uchardet_dir.split(os.pathsep),
     "library_dirs": uchardet_dir.split(os.pathsep),
-    "extra_compile_args": ["-DNDEBUG", "-Dlibuchardet_EXPORTS", "-Wall", "-O3", "-std=c++11"],
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,8 @@ setup(
     ext_modules=cythonize(
         [
             cchardet_module,
-        ]
+        ],
+        cplus=True,
+        compiler_directives={"language_level": "3"},  # Python 3
     ),
 )

--- a/src/tests/cchardet_test.py
+++ b/src/tests/cchardet_test.py
@@ -4,17 +4,18 @@ import platform
 
 import cchardet
 import pytest
-
+import sys
 SKIP_LIST = [
     os.path.join('src','tests','testdata','ja','utf-16le.txt'),
     os.path.join('src','tests','testdata','ja','utf-16be.txt'),
     os.path.join('src','tests','testdata','es','iso-8859-15.txt'),
     os.path.join('src','tests','testdata','da','iso-8859-1.txt'),
-    os.path.join('src','tests','testdata','he','iso-8859-8.txt'),
-    # Fail on i686 only
-    os.path.join('src','tests','testdata','th','tis-620.txt'),
-    
+    os.path.join('src','tests','testdata','he','iso-8859-8.txt'),    
 ]
+
+if sys.maxsize <= 2**32:
+    # Fails on i686 only, original cchardet test fails too
+    SKIP_LIST.append(os.path.join('src','tests','testdata','th','tis-620.txt')))
 
 # Python can't decode encoding
 SKIP_LIST_02 = [

--- a/src/tests/cchardet_test.py
+++ b/src/tests/cchardet_test.py
@@ -11,6 +11,9 @@ SKIP_LIST = [
     os.path.join('src','tests','testdata','es','iso-8859-15.txt'),
     os.path.join('src','tests','testdata','da','iso-8859-1.txt'),
     os.path.join('src','tests','testdata','he','iso-8859-8.txt'),
+    # Fail on i686 only
+    os.path.join('src','tests','testdata','th','tis-620.txt'),
+    
 ]
 
 # Python can't decode encoding
@@ -18,6 +21,7 @@ SKIP_LIST_02 = [
     os.path.join('src','tests','testdata','vi','viscii.txt'),
     os.path.join('src','tests','testdata','zh','euc-tw.txt'),
 ]
+
 SKIP_LIST_02.extend(SKIP_LIST)
 
 

--- a/src/tests/cchardet_test.py
+++ b/src/tests/cchardet_test.py
@@ -15,7 +15,7 @@ SKIP_LIST = [
 
 if sys.maxsize <= 2**32:
     # Fails on i686 only, original cchardet test fails too
-    SKIP_LIST.append(os.path.join('src','tests','testdata','th','tis-620.txt')))
+    SKIP_LIST.append(os.path.join('src','tests','testdata','th','tis-620.txt'))
 
 # Python can't decode encoding
 SKIP_LIST_02 = [

--- a/src/tests/cchardet_test.py
+++ b/src/tests/cchardet_test.py
@@ -17,6 +17,8 @@ SKIP_LIST = [
 if sys.maxsize <= 2**32:
     # Fails on i686 only, original cchardet test fails too
     SKIP_LIST.append(os.path.join("src", "tests", "testdata", "th", "tis-620.txt"))
+    SKIP_LIST.append(os.path.join("src", "tests", "testdata", "fi", "iso-8859-1.txt"))
+    SKIP_LIST.append(os.path.join("src", "tests", "testdata", "ga", "iso-8859-1.txt"))
 
 # Python can't decode encoding
 SKIP_LIST_02 = [

--- a/src/tests/cchardet_test.py
+++ b/src/tests/cchardet_test.py
@@ -5,49 +5,63 @@ import platform
 import cchardet
 import pytest
 import sys
+
 SKIP_LIST = [
-    os.path.join('src','tests','testdata','ja','utf-16le.txt'),
-    os.path.join('src','tests','testdata','ja','utf-16be.txt'),
-    os.path.join('src','tests','testdata','es','iso-8859-15.txt'),
-    os.path.join('src','tests','testdata','da','iso-8859-1.txt'),
-    os.path.join('src','tests','testdata','he','iso-8859-8.txt'),    
+    os.path.join("src", "tests", "testdata", "ja", "utf-16le.txt"),
+    os.path.join("src", "tests", "testdata", "ja", "utf-16be.txt"),
+    os.path.join("src", "tests", "testdata", "es", "iso-8859-15.txt"),
+    os.path.join("src", "tests", "testdata", "da", "iso-8859-1.txt"),
+    os.path.join("src", "tests", "testdata", "he", "iso-8859-8.txt"),
 ]
 
 if sys.maxsize <= 2**32:
     # Fails on i686 only, original cchardet test fails too
-    SKIP_LIST.append(os.path.join('src','tests','testdata','th','tis-620.txt'))
+    SKIP_LIST.append(os.path.join("src", "tests", "testdata", "th", "tis-620.txt"))
 
 # Python can't decode encoding
 SKIP_LIST_02 = [
-    os.path.join('src','tests','testdata','vi','viscii.txt'),
-    os.path.join('src','tests','testdata','zh','euc-tw.txt'),
+    os.path.join("src", "tests", "testdata", "vi", "viscii.txt"),
+    os.path.join("src", "tests", "testdata", "zh", "euc-tw.txt"),
 ]
 
 SKIP_LIST_02.extend(SKIP_LIST)
 
 
 def test_ascii():
-    detected_encoding = cchardet.detect(b'abcdefghijklmnopqrstuvwxyz')
-    assert 'ascii' == detected_encoding['encoding'].lower()
+    detected_encoding = cchardet.detect(b"abcdefghijklmnopqrstuvwxyz")
+    assert "ascii" == detected_encoding["encoding"].lower()
 
 
-@pytest.mark.parametrize("testfile", glob.glob(os.path.join('src','tests','testdata','*','*.txt')))
+@pytest.mark.parametrize(
+    "testfile", glob.glob(os.path.join("src", "tests", "testdata", "*", "*.txt"))
+)
 def test_detect(testfile):
     if testfile.replace("\\", "/") in SKIP_LIST:
         return
 
     base = os.path.basename(testfile)
     expected_charset = os.path.splitext(base)[0]
-    with open(testfile, 'rb') as f:
+    with open(testfile, "rb") as f:
         msg = f.read()
         detected_encoding = cchardet.detect(msg)
-        assert expected_charset.lower() == detected_encoding['encoding'].lower()
+        assert expected_charset.lower() == detected_encoding["encoding"].lower()
 
 
-@pytest.mark.skipif(platform.system() == 'Windows', reason="FIXME: Cannot find test file on Windows for some reason")
+@pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason="FIXME: Cannot find test file on Windows for some reason",
+)
 def test_detector():
     detector = cchardet.UniversalDetector()
-    with open(os.path.join('src','tests','samples','wikipediaJa_One_Thousand_and_One_Nights_SJIS.txt'), 'rb') as f:
+    with open(
+        os.path.join(
+            "src",
+            "tests",
+            "samples",
+            "wikipediaJa_One_Thousand_and_One_Nights_SJIS.txt",
+        ),
+        "rb",
+    ) as f:
         line = f.readline()
         while line:
             detector.feed(line)
@@ -56,14 +70,14 @@ def test_detector():
             line = f.readline()
     detector.close()
     detected_encoding = detector.result
-    assert "shift_jis" == detected_encoding['encoding'].lower()
+    assert "shift_jis" == detected_encoding["encoding"].lower()
 
 
 def test_github_issue_20():
     """
     https://github.com/PyYoshi/cChardet/issues/20
     """
-    msg = b'\x8f'
+    msg = b"\x8f"
 
     cchardet.detect(msg)
 
@@ -73,14 +87,14 @@ def test_github_issue_20():
 
 
 def test_decode():
-    testfiles = glob.glob(os.path.join('src','tests','testdata','*','*.txt'))
+    testfiles = glob.glob(os.path.join("src", "tests", "testdata", "*", "*.txt"))
     for testfile in testfiles:
         if testfile.replace("\\", "/") in SKIP_LIST_02:
             continue
 
         base = os.path.basename(testfile)
         expected_charset = os.path.splitext(base)[0]
-        with open(testfile, 'rb') as f:
+        with open(testfile, "rb") as f:
             msg = f.read()
         detected_encoding = cchardet.detect(msg)
         try:

--- a/src/tests/cchardet_test.py
+++ b/src/tests/cchardet_test.py
@@ -31,18 +31,17 @@ def test_ascii():
     assert 'ascii' == detected_encoding['encoding'].lower()
 
 
-def test_detect():
-    testfiles = glob.glob(os.path.join('src','tests','testdata','*','*.txt'))
-    for testfile in testfiles:
-        if testfile.replace("\\", "/") in SKIP_LIST:
-            continue
+@pytest.mark.parametrize("testfile", glob.glob(os.path.join('src','tests','testdata','*','*.txt')))
+def test_detect(testfile):
+    if testfile.replace("\\", "/") in SKIP_LIST:
+        return
 
-        base = os.path.basename(testfile)
-        expected_charset = os.path.splitext(base)[0]
-        with open(testfile, 'rb') as f:
-            msg = f.read()
-            detected_encoding = cchardet.detect(msg)
-            assert expected_charset.lower() == detected_encoding['encoding'].lower()
+    base = os.path.basename(testfile)
+    expected_charset = os.path.splitext(base)[0]
+    with open(testfile, 'rb') as f:
+        msg = f.read()
+        detected_encoding = cchardet.detect(msg)
+        assert expected_charset.lower() == detected_encoding['encoding'].lower()
 
 
 @pytest.mark.skipif(platform.system() == 'Windows', reason="FIXME: Cannot find test file on Windows for some reason")


### PR DESCRIPTION
`python3 -m pep517.check .` now passes

Test run https://github.com/bdraco/cChardet/actions/runs/4219774165

The extension has returned to having the modified uchardet directly linked in.

This is currently blocking Home Assistant from using this library with python 3.11 until we can get a new release with working pep517 builds.

https://github.com/home-assistant/core/actions/runs/4217296920/jobs/7320979916

Thanks for looking at this PR!